### PR TITLE
signs the image digest rather than the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,32 +56,27 @@ jobs:
         run: echo "OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Build and push container
+        id: build
         env:
           KO_DOCKER_REPO: ghcr.io/${{ steps.repo_owner.outputs.OWNER }}/yardstick
           VERSION: ${{ steps.tag.outputs.VERSION }}
           CREATION_TIME: $(date -u +'%Y-%m-%dT%H:%M:%SZ')
         run: |
           # Build and push the container with reproducible build flags
-          ko build \
+          # Ko outputs the full image reference with digest
+          DIGEST=$(ko build \
             --bare \
             --sbom=spdx \
             --platform=linux/amd64,linux/arm64 \
             --base-import-paths \
             --tags $VERSION,latest \
-            ./cmd/yardstick-server
+            ./cmd/yardstick-server)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Sign Image with Cosign
-        env:
-          KO_DOCKER_REPO: ghcr.io/${{ steps.repo_owner.outputs.OWNER }}/yardstick
         run: |
-          TAG=$(echo "${{ steps.tag.outputs.VERSION }}" | sed 's/+/_/g')
-          # Sign the ko image
-          cosign sign -y $KO_DOCKER_REPO/server:$TAG
-
-          # Sign the latest tag if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            cosign sign -y $KO_DOCKER_REPO/server:latest
-          fi
+          # Sign the image by digest (immutable reference)
+          cosign sign -y ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
We have error in the build after moving to cosign 4.0.0. https://github.com/StacklokLabs/yardstick/actions/runs/19801963659/job/56730546601

This PR signs the digest rather than just the tag and also ensures to sign `yardstick-server` not `server`