### PR TITLE
chore: upgrade Go to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackloklabs/yardstick
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/google/jsonschema-go v0.4.2


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `go.mod` from `1.26.1` to `1.26.2` (latest stable).
- CI workflows resolve the toolchain via `go-version-file: 'go.mod'`, so no workflow changes are required.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)