### PR TITLE
ci: adopt golangci-lint v2.12.1 and fix goconst findings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
+          version: v2.11.4
           args: --timeout=5m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.4
+          version: v2.12.1
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,7 @@ linters:
           - errcheck
           - dupl
           - gosec
+          - goconst
           - paralleltest
         path: (.+)_test\.go
       - linters:

--- a/cmd/yardstick-client/main.go
+++ b/cmd/yardstick-client/main.go
@@ -15,6 +15,14 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const (
+	transportStdio          = "stdio"
+	transportSSE            = "sse"
+	transportStreamableHTTP = "streamable-http"
+
+	defaultAddress = "localhost"
+)
+
 // Config holds the client configuration
 type Config struct {
 	Transport string
@@ -45,11 +53,11 @@ func (c *Client) Connect(ctx context.Context) error {
 	var err error
 
 	switch c.config.Transport {
-	case "stdio":
+	case transportStdio:
 		transport, err = c.connectStdio()
-	case "sse":
+	case transportSSE:
 		transport, err = c.connectSSE()
-	case "streamable-http":
+	case transportStreamableHTTP:
 		transport, err = c.connectStreamableHTTP()
 	default:
 		return fmt.Errorf("unsupported transport type: %s", c.config.Transport)
@@ -184,8 +192,8 @@ func (c *Client) GetServerInfo(ctx context.Context) error {
 // parseConfig parses command line flags and environment variables
 func parseConfig() Config {
 	config := Config{
-		Transport: "stdio",
-		Address:   "localhost",
+		Transport: transportStdio,
+		Address:   defaultAddress,
 		Port:      8080,
 		Timeout:   30 * time.Second,
 	}


### PR DESCRIPTION
## Summary
- Pin `golangci-lint` to **v2.12.1** in `.github/workflows/lint.yml`. The action was unpinned and auto-installing the latest binary, which broke `main` when v2.12.1 shipped with stricter `goconst` defaults.
- Fix the production-code `goconst` findings in `cmd/yardstick-client/main.go` by extracting transport name constants (`"stdio"`, `"sse"`, `"streamable-http"`) and a default address constant (`"localhost"`).
- Exclude `goconst` from `(.+)_test\.go` in `.golangci.yml`. Test fixtures legitimately repeat literals like `"hello"` and `"test123"`; forcing constants there adds noise without value, and matches the existing test-file exclusions for `lll`, `gocyclo`, `errcheck`, `dupl`, `gosec`, `paralleltest`.

Verified locally with `golangci-lint v2.12.1`: `0 issues.`

## Test plan
- [ ] Linting workflow passes on this PR
- [ ] Action logs show `Installing golangci-lint binary v2.12.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)