### PR TITLE
Fix/security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackloklabs/yardstick
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/jsonschema-go v0.4.3


### PR DESCRIPTION
### Summary:
  Grype image scans against main started failing on the medium severity cutoff. The Ko-built binary embeds the Go stdlib version, and Go 1.26.2 (current main) is missing 21 stdlib CVE fixes — including 1 Critical (CVE-2026-27143)
   and 12 High — that landed in 1.26.3.

#### Change: 
- go.mod: go 1.26.2 → go 1.26.3. CI workflows resolve Go via go-version-file: 'go.mod', so no workflow edits needed.

#### Verification:
  - Rebuilt the Ko image locally with Go 1.26.3 → grype --only-fixed --fail-on medium: No vulnerabilities found
  - Filesystem scan on a clean checkout simulation: No vulnerabilities found